### PR TITLE
DOC: Add name of trigger channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If 'Unsampled String Markers' is checked, the app will create a Marker stream on
 
 ### EEG Channel
 
-If this box is checked, an extra channel will be added to the EEG stream corresponding to the device triggers in. Rather than unsampled markers, these channels will output -1 if no trigger is available, else the value corresponding to the value at the trigger input when it changes value.
+If this box is checked, an extra channel named `"triggerStream"` will be added to the EEG stream corresponding to the device triggers in. Rather than unsampled markers, these channels will output -1 if no trigger is available, else the value corresponding to the value at the trigger input when it changes value.
 
 ### Activate bits 8-15
 


### PR DESCRIPTION
Adding the expected name of the trigger channel to the documentation.

See: https://github.com/brain-products/LSL-BrainAmpSeries/blob/f4f6dc52c30445ec3a0f72f3fe1315e2595f921c/mainwindow.cpp#L690